### PR TITLE
Camera shake

### DIFF
--- a/Assets/Breakout.unitypackage.meta
+++ b/Assets/Breakout.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6c229b9a111787a43964cf67ae370a7a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/_Scenes/Level 1.unity
+++ b/Assets/_Scenes/Level 1.unity
@@ -320,6 +320,7 @@ GameObject:
   - component: {fileID: 196396962}
   - component: {fileID: 196396961}
   - component: {fileID: 196396960}
+  - component: {fileID: 196396964}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -445,6 +446,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 63.454, y: 0, z: 0}
+--- !u!114 &196396964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196396959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e4a133be4de3ce4c8ba2ff594ba283b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &269931761 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4379782071263056144, guid: 329927099c3f0824b9a9bd04beac8c6d, type: 3}
@@ -578,6 +591,8 @@ MonoBehaviour:
   maxLives: 3
   ball: {fileID: 2054714181}
   bricksContainer: {fileID: 1170594424}
+  screenShakeStrength: 3
+  screenShakeDuration: 1
 --- !u!1001 &443665624
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/Level 1.unity
+++ b/Assets/_Scenes/Level 1.unity
@@ -536,6 +536,7 @@ GameObject:
   - component: {fileID: 356058013}
   - component: {fileID: 356058011}
   - component: {fileID: 356058014}
+  - component: {fileID: 356058015}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -591,8 +592,23 @@ MonoBehaviour:
   maxLives: 3
   ball: {fileID: 2054714181}
   bricksContainer: {fileID: 1170594424}
-  screenShakeStrength: 3
-  screenShakeDuration: 1
+--- !u!114 &356058015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356058010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf1a50240266ce041a59413948758e05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  strengthBase: 0.5
+  strengthMultiplier: 0.5
+  durationBase: 0.5
+  durationMultiplier: 0.5
+  maxTimeBetweenBreaks: 1.5
 --- !u!1001 &443665624
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/Level 2.unity
+++ b/Assets/_Scenes/Level 2.unity
@@ -2067,6 +2067,7 @@ GameObject:
   - component: {fileID: 1355270213}
   - component: {fileID: 1355270212}
   - component: {fileID: 1355270211}
+  - component: {fileID: 1355270215}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2192,6 +2193,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 63.454, y: 0, z: 0}
+--- !u!114 &1355270215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355270210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e4a133be4de3ce4c8ba2ff594ba283b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1393726363
 GameObject:
   m_ObjectHideFlags: 0
@@ -2491,6 +2504,8 @@ MonoBehaviour:
   maxLives: 3
   ball: {fileID: 4561635119993004754}
   bricksContainer: {fileID: 796630123}
+  screenShakeStrength: 3
+  screenShakeDuration: 1
 --- !u!1 &1622247664
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Scenes/Level 2.unity
+++ b/Assets/_Scenes/Level 2.unity
@@ -2449,6 +2449,7 @@ GameObject:
   - component: {fileID: 1576275138}
   - component: {fileID: 1576275136}
   - component: {fileID: 1576275139}
+  - component: {fileID: 1576275140}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -2504,8 +2505,23 @@ MonoBehaviour:
   maxLives: 3
   ball: {fileID: 4561635119993004754}
   bricksContainer: {fileID: 796630123}
-  screenShakeStrength: 3
-  screenShakeDuration: 1
+--- !u!114 &1576275140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1576275135}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf1a50240266ce041a59413948758e05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  strengthBase: 0.5
+  strengthMultiplier: 0.5
+  durationBase: 0.5
+  durationMultiplier: 0.5
+  maxTimeBetweenBreaks: 1.5
 --- !u!1 &1622247664
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Scripts/GameManager.cs
+++ b/Assets/_Scripts/GameManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using JetBrains.Annotations;
 using UnityEngine;
 
 public class GameManager : SingletonMonoBehavior<GameManager>
@@ -6,9 +7,6 @@ public class GameManager : SingletonMonoBehavior<GameManager>
     [SerializeField] private int maxLives = 3;
     [SerializeField] private Ball ball;
     [SerializeField] private Transform bricksContainer;
-
-    [SerializeField] private float screenShakeStrength;
-    [SerializeField] private float screenShakeDuration;
 
     private int currentBrickCount;
     private int totalBrickCount;
@@ -39,7 +37,7 @@ public class GameManager : SingletonMonoBehavior<GameManager>
         AudioManager.Instance.PlaySFX("destroyBlock");
         // implement particle effect here
         // add camera shake here
-        ScreenShake.Shake(screenShakeStrength, screenShakeDuration);
+        ShakeManager.addShake();
         currentBrickCount--;
         Debug.Log($"Destroyed Brick at {position}, {currentBrickCount}/{totalBrickCount} remaining");
         if (currentBrickCount == 0)

--- a/Assets/_Scripts/GameManager.cs
+++ b/Assets/_Scripts/GameManager.cs
@@ -7,6 +7,9 @@ public class GameManager : SingletonMonoBehavior<GameManager>
     [SerializeField] private Ball ball;
     [SerializeField] private Transform bricksContainer;
 
+    [SerializeField] private float screenShakeStrength;
+    [SerializeField] private float screenShakeDuration;
+
     private int currentBrickCount;
     private int totalBrickCount;
 
@@ -36,6 +39,7 @@ public class GameManager : SingletonMonoBehavior<GameManager>
         AudioManager.Instance.PlaySFX("destroyBlock");
         // implement particle effect here
         // add camera shake here
+        ScreenShake.Shake(screenShakeStrength, screenShakeDuration);
         currentBrickCount--;
         Debug.Log($"Destroyed Brick at {position}, {currentBrickCount}/{totalBrickCount} remaining");
         if (currentBrickCount == 0)

--- a/Assets/_Scripts/ScreenShake.cs
+++ b/Assets/_Scripts/ScreenShake.cs
@@ -1,0 +1,20 @@
+using DG.Tweening;
+using UnityEngine;
+
+public class ScreenShake : MonoBehaviour
+{
+
+
+    public static ScreenShake Instance;
+
+    private void Awake() => Instance = this;
+
+    
+    private void OnShake(float duration, float strength)
+    {
+        transform.DOShakePosition(duration, strength);
+        transform.DOShakeRotation(duration, strength);
+    }
+
+    public static void Shake(float duration, float strength) => Instance.OnShake(duration, strength);
+}

--- a/Assets/_Scripts/ScreenShake.cs.meta
+++ b/Assets/_Scripts/ScreenShake.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e4a133be4de3ce4c8ba2ff594ba283b

--- a/Assets/_Scripts/ShakeManager.cs
+++ b/Assets/_Scripts/ShakeManager.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class ShakeManager : SingletonMonoBehavior<ShakeManager>
+{
+    [SerializeField] private float strengthBase = 0.5f;
+    [SerializeField] private float strengthMultiplier = 0.5f;
+    [SerializeField] private float durationBase = 0.5f;
+    [SerializeField] private float durationMultiplier = 0.5f;
+    [SerializeField] private float maxTimeBetweenBreaks = 1.5f;
+
+    private float screenShakeStrength = ShakeManager.Instance.strengthBase;
+    private float screenShakeDuration = ShakeManager.Instance.durationBase;
+    private float lastBlockBreak;
+    
+
+    // checks to see if the time between the last block broken and now is within the combo timer, and if so, makes the screen shake stronger. If it isn't, it's a normal
+    // screen shake
+    public static void addShake()
+    {
+        if(Time.time - ShakeManager.Instance.lastBlockBreak < ShakeManager.Instance.maxTimeBetweenBreaks)
+        {
+            ShakeManager.Instance.screenShakeDuration += ShakeManager.Instance.durationMultiplier;
+            ShakeManager.Instance.screenShakeStrength += ShakeManager.Instance.strengthMultiplier;
+        } else
+        {
+            ShakeManager.Instance.screenShakeDuration = ShakeManager.Instance.durationBase;
+            ShakeManager.Instance.screenShakeStrength = ShakeManager.Instance.strengthBase;
+        }
+        InstantiateShake(ShakeManager.Instance.screenShakeDuration, ShakeManager.Instance.screenShakeStrength);
+        ShakeManager.Instance.lastBlockBreak = Time.time;
+    }
+
+    // method that actually calls the camera to be shaken
+    public static void InstantiateShake(float duration, float strength)
+    {
+        ScreenShake.Shake(duration, strength);
+    }
+}

--- a/Assets/_Scripts/ShakeManager.cs.meta
+++ b/Assets/_Scripts/ShakeManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf1a50240266ce041a59413948758e05


### PR DESCRIPTION
Added camera shake functionality.

The camera shakes every time that a block is broken.

The camera shake strength and duration also increases for each block broken within a given time of each other, currently set to 1.5 seconds. The camera shake will get a stacking increase to strength and duration when the blocks are broken within this time, and if the next block broken is outside of this timespan, then it is reset to a normal shake strength and duration.

This is done via implementing a Singleton ShakeManager that is attached to the GameManager object. Every time a block is broken, it calls on the ShakeManager addShake() method.